### PR TITLE
Use sinon for unit tests and include dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-dist
 node_modules

--- a/dist/ldap-strat.js
+++ b/dist/ldap-strat.js
@@ -1,0 +1,312 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _passportStrategy = require('passport-strategy');
+
+var _passportStrategy2 = _interopRequireDefault(_passportStrategy);
+
+var _ldapjs = require('ldapjs');
+
+var _ldapjs2 = _interopRequireDefault(_ldapjs);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * @class Strategy
+ * @description LDAP implementation of passport-strategy.
+ */
+
+var Strategy = function (_ParentStrategy) {
+    _inherits(Strategy, _ParentStrategy);
+
+    /**
+     * Constructor for Strategy.<br>
+     * Various options can be specified to modify the authentication
+     * and post-auth search behavior.
+     *
+     * @param {object} options The configuration options
+     * @param {function} verify The search verify method {optional}
+     * @api public
+     */
+
+    function Strategy(options, verify) {
+        _classCallCheck(this, Strategy);
+
+        var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Strategy).call(this));
+
+        if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) !== 'object' || !options || verify && typeof verify !== 'function') {
+            throw new Error('Invalid parameters for Strategy constructor.');
+        }
+        // assign a name for passport
+        _this.name = 'ldap';
+        // set some defaults
+        _this._options = _this._defaultOptions(options);
+        _this._verify = verify || _this._defaultVerify;
+        // ensure these methods are set for standalone use
+        _this.success = _this.success || function () {};
+        _this.fail = _this.fail || function () {};
+        return _this;
+    }
+
+    /**
+     * Performs authentication against the configured LDAP server.
+     *
+     * @param {object} req The http request containing a `body` with request credentials
+     * @return {Promise} A promise resolving to the configured search results or the user dn
+     * @api public
+     */
+
+
+    _createClass(Strategy, [{
+        key: 'authenticate',
+        value: function authenticate(req) {
+            var _this2 = this;
+
+            return new Promise(function (resolve, reject) {
+                if (!req) {
+                    return _this2._fail(new Error('Missing req parameter.'), reject);
+                }
+                var client = Strategy._createLdapClient(_this2._options.server);
+                client.on('error', function (err) {
+                    return _this2._fail(err, reject);
+                });
+
+                // bind to ldap with the req data
+                _this2._bind(client, req.body).then(function (res) {
+                    return _this2._success(res, resolve);
+                }).catch(function (err) {
+                    // console.log('failed auth', err);
+                    return _this2._fail(err, reject);
+                });
+            });
+        }
+
+        /**
+         * Performs an ldap bind using the specified credentials.
+         *
+         * @param {object} client The ldap client to bind with
+         * @param {object} body The HTTP request body containing credentials to use when binding
+         * @return {Promise} A promise containing the dn or search results
+         * @api private
+         */
+
+    }, {
+        key: '_bind',
+        value: function _bind(client, body) {
+            var _this3 = this;
+
+            return new Promise(function (resolve, reject) {
+                var credentials = _this3._getValidatedCredentials(body);
+                client.bind(credentials.username, credentials.password, function (err) {
+                    if (err) {
+                        // console.log('bind error', err);
+                        return reject(err);
+                    }
+                    if (!_this3._options.search || !_this3._options.search.filter) {
+                        // success, end early if no search is needed
+                        return resolve(credentials.username);
+                    }
+                    // copy so we can replace template pieces
+                    var search = Object.assign({}, _this3._options.search);
+                    // replace any placeholders with the original username
+                    search.filter = search.filter.replace(/\$\{.*\}/, credentials.originalUsername);
+                    // console.log('finished bind - now search', search);
+
+                    return resolve(_this3._search(client, search));
+                });
+            });
+        }
+
+        /**
+         * Performs an ldap search using the specified search details.<br>
+         * All search entries and references are pooled into an array and returned on end.
+         *
+         * @param {object} client The ldap client to search with
+         * @param {object} search The search object containing the filter, etc
+         * @return {Promise} A promise containing the search results
+         * @api private
+         */
+
+    }, {
+        key: '_search',
+        value: function _search(client, search) {
+            var _this4 = this;
+
+            return new Promise(function (resolve, reject) {
+                client.search(search.base, search, function (err, res) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    var results = [];
+                    res.on('searchEntry', function (entry) {
+                        // TODO: emit event
+                        results.push(entry.object);
+                    });
+                    res.on('searchReference', function (reference) {
+                        // TODO: emit event
+                        results.push(reference.uris);
+                    });
+                    res.on('error', function (err) {
+                        // TODO: emit event
+                        return reject(err);
+                    });
+                    res.on('end', function (result) {
+                        // TODO: emit event
+                        if (result.status !== 0) {
+                            return reject(new Error(result));
+                        }
+                        _this4._verify(results, function (err, searchResults) {
+                            if (err) {
+                                return reject(err);
+                            }
+                            return resolve(searchResults);
+                        });
+                    });
+                });
+            });
+        }
+
+        /**
+         * Returns an ldap client.
+         *
+         * @param {object} serverOptions The server details
+         * @return {object} An ldap client
+         * @api private
+         */
+
+    }, {
+        key: '_success',
+
+
+        /**
+         * Handles authenticate success.
+         *
+         * @param {object} res Authenticate response
+         * @param {function} resolve Used to resolve authenticate's promise
+         * @return {void} Result of resolve function
+         * @api private
+         */
+        value: function _success(res, resolve) {
+            this.success(res);
+            return resolve(res);
+        }
+
+        /**
+         * Handles authenticate failure.
+         *
+         * @param {Error} err Error object thrown during authenticate
+         * @param {function} reject Used to reject authenticate's promise
+         * @return {void} Result of reject function
+         * @api private
+         */
+
+    }, {
+        key: '_fail',
+        value: function _fail(err, reject) {
+            this.fail(err);
+            return reject(err);
+        }
+
+        /**
+         * Default verify, forwards the search data.
+         *
+         * @param {object} data Search results
+         * @param {function} done Callback
+         * @return {object} Result of done function
+         * @api private
+         */
+
+    }, {
+        key: '_defaultVerify',
+        value: function _defaultVerify(data, done) {
+            return done(null, data);
+        }
+
+        /**
+         * Defaults some basic option fields.
+         *
+         * @param {object} options The passed in options
+         * @return {object} The options with defaults set (if necessary)
+         * @api private
+         */
+
+    }, {
+        key: '_defaultOptions',
+        value: function _defaultOptions(options) {
+            options.usernameField = options.usernameField || 'username';
+            options.passwordField = options.passwordField || 'password';
+            options.uidTag = options.uidTag || 'uid';
+            if (options.search) {
+                options.search.base = options.search.base || '';
+            }
+            return options;
+        }
+
+        /**
+         * Builds a credentials object from an http request body.
+         *
+         * @param {object} body The request body, containing user's credentials
+         * @return {object} A formatted object containing the user's credentials
+         * @api private
+         */
+
+    }, {
+        key: '_getValidatedCredentials',
+        value: function _getValidatedCredentials(body) {
+            body = body || {};
+            var user = {
+                'username': body[this._options.usernameField],
+                'password': body[this._options.passwordField],
+                'originalUsername': body[this._options.usernameField]
+            };
+            if (!user.username || !user.password) {
+                // console.log('Missing username or password parameters.', user);
+                throw new _ldapjs2.default.InvalidCredentialsError('Missing username or password parameters.');
+            }
+            user.username = this._toSearchDn(body.username);
+
+            return user;
+        }
+
+        /**
+         * Builds the dn based on configured uidTag and base.
+         *
+         * @param {string} username The user
+         * @return {string} The user's dn
+         * @api private
+         */
+
+    }, {
+        key: '_toSearchDn',
+        value: function _toSearchDn(username) {
+            var base = this._options.base || '';
+            if (base.constructor === Array) {
+                base = base.join(',');
+            }
+            return this._options.uidTag + '=' + username + (base ? ',' + base : '');
+        }
+    }], [{
+        key: '_createLdapClient',
+        value: function _createLdapClient(serverOptions) {
+            return _ldapjs2.default.createClient(serverOptions);
+        }
+    }]);
+
+    return Strategy;
+}(_passportStrategy2.default);
+
+exports.default = Strategy;
+

--- a/dist/ldap-strat.js
+++ b/dist/ldap-strat.js
@@ -88,7 +88,6 @@ var Strategy = function (_ParentStrategy) {
                 _this2._bind(client, req.body).then(function (res) {
                     return _this2._success(res, resolve);
                 }).catch(function (err) {
-                    // console.log('failed auth', err);
                     return _this2._fail(err, reject);
                 });
             });
@@ -159,8 +158,8 @@ var Strategy = function (_ParentStrategy) {
                         // TODO: emit event
                         results.push(reference.uris);
                     });
+                    // TODO: emit event
                     res.on('error', function (err) {
-                        // TODO: emit event
                         return reject(err);
                     });
                     res.on('end', function (result) {

--- a/lib/ldap-strat.js
+++ b/lib/ldap-strat.js
@@ -44,7 +44,7 @@ class Strategy extends ParentStrategy {
             if (!req) {
                 return this._fail(new Error('Missing req parameter.'), reject);
             }
-            const client = ldap.createClient(this._options.server);
+            const client = Strategy._createLdapClient(this._options.server);
             client.on('error', (err) => {
                 return this._fail(err, reject);
             });
@@ -135,6 +135,17 @@ class Strategy extends ParentStrategy {
                 });
             });
         });
+    }
+
+    /**
+     * Returns an ldap client.
+     *
+     * @param {object} serverOptions The server details
+     * @return {object} An ldap client
+     * @api private
+     */
+    static _createLdapClient(serverOptions) {
+        return ldap.createClient(serverOptions);
     }
 
     /**

--- a/lib/ldap-strat.js
+++ b/lib/ldap-strat.js
@@ -71,7 +71,7 @@ class Strategy extends ParentStrategy {
      */
     _bind(client, body) {
         return new Promise((resolve, reject) => {
-            let credentials = this._getValidatedCredentials(body);
+            const credentials = this._getValidatedCredentials(body);
             client.bind(credentials.username, credentials.password, (err) => {
                 if (err) {
                     // console.log('bind error', err);
@@ -82,7 +82,7 @@ class Strategy extends ParentStrategy {
                     return resolve(credentials.username);
                 }
                 // copy so we can replace template pieces
-                let search = Object.assign({}, this._options.search);
+                const search = Object.assign({}, this._options.search);
                 // replace any placeholders with the original username
                 search.filter = search.filter.replace(/\$\{.*\}/, credentials.originalUsername);
                 // console.log('finished bind - now search', search);
@@ -108,7 +108,7 @@ class Strategy extends ParentStrategy {
                 if (err) {
                     return reject(err);
                 }
-                let results = [];
+                const results = [];
                 res.on('searchEntry', (entry) => {
                     // TODO: emit event
                     results.push(entry.object);
@@ -212,7 +212,7 @@ class Strategy extends ParentStrategy {
      */
     _getValidatedCredentials(body) {
         body = body || {};
-        let user = {
+        const user = {
             'username': body[this._options.usernameField],
             'password': body[this._options.passwordField],
             'originalUsername': body[this._options.usernameField]

--- a/lib/ldap-strat.js
+++ b/lib/ldap-strat.js
@@ -5,7 +5,7 @@ import ldap from 'ldapjs';
  * @class Strategy
  * @description LDAP implementation of passport-strategy.
  */
-class Strategy extends ParentStrategy {
+export default class Strategy extends ParentStrategy {
 
     /**
      * Constructor for Strategy.<br>
@@ -45,19 +45,12 @@ class Strategy extends ParentStrategy {
                 return this._fail(new Error('Missing req parameter.'), reject);
             }
             const client = Strategy._createLdapClient(this._options.server);
-            client.on('error', (err) => {
-                return this._fail(err, reject);
-            });
+            client.on('error', err => this._fail(err, reject));
 
             // bind to ldap with the req data
             this._bind(client, req.body)
-            .then((res) => {
-                return this._success(res, resolve);
-            })
-            .catch((err) => {
-                // console.log('failed auth', err);
-                return this._fail(err, reject);
-            });
+            .then(res => this._success(res, resolve))
+            .catch(err => this._fail(err, reject));
         });
     }
 
@@ -117,10 +110,8 @@ class Strategy extends ParentStrategy {
                     // TODO: emit event
                     results.push(reference.uris);
                 });
-                res.on('error', (err) => {
-                    // TODO: emit event
-                    return reject(err);
-                });
+                // TODO: emit event
+                res.on('error', err => reject(err));
                 res.on('end', (result) => {
                     // TODO: emit event
                     if (result.status !== 0) {
@@ -244,5 +235,3 @@ class Strategy extends ParentStrategy {
     }
 
 }
-
-export default Strategy;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "name": "Stephan DeSouza"
   },
   "scripts": {
+    "build": "mkdir -p dist && babel lib/ldap-strat.js > dist/ldap-strat.js",
     "test": "mocha --compilers js:babel-register test/suite.js",
     "install": "mkdir -p dist && babel lib/ldap-strat.js > dist/ldap-strat.js"
   },
@@ -20,7 +21,8 @@
     "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "^6.6.0",
     "ldapjs": "1.0.0",
-    "passport-strategy": "^1.0.0"
+    "passport-strategy": "^1.0.0",
+    "sinon": "^1.17.4"
   },
   "devDependencies": {
     "babel-cli": "^6.6.4",

--- a/package.json
+++ b/package.json
@@ -1,31 +1,27 @@
 {
   "name": "passport-ldap-strat",
-  "contributors": [
-    {
-      "name": "Ben Plessinger"
-    }
-  ],
   "version": "0.0.1",
   "description": "ldap strategy for passport",
   "main": "dist/ldap-strat.js",
+  "scripts": {
+      "build": "mkdir -p dist && babel lib/ldap-strat.js > dist/ldap-strat.js",
+      "test": "mocha --compilers js:babel-register test/suite.js"
+  },
   "author": {
     "name": "Stephan DeSouza"
   },
-  "scripts": {
-    "build": "mkdir -p dist && babel lib/ldap-strat.js > dist/ldap-strat.js",
-    "test": "mocha --compilers js:babel-register test/suite.js",
-    "install": "mkdir -p dist && babel lib/ldap-strat.js > dist/ldap-strat.js"
-  },
+  "contributors": [
+      {
+          "name": "Ben Plessinger"
+      }
+  ],
   "dependencies": {
-    "babel-cli": "^6.8.0",
     "babel-polyfill": "^6.6.1",
-    "babel-preset-es2015": "^6.6.0",
     "ldapjs": "1.0.0",
-    "passport-strategy": "^1.0.0",
-    "sinon": "^1.17.4"
+    "passport-strategy": "^1.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.4",
+    "babel-cli": "^6.8.0",
     "babel-eslint": "^5.0.0-beta",
     "babel-preset-es2015": "^6.6.0",
     "body-parser": "^1.15.0",
@@ -34,6 +30,7 @@
     "express": "^4.13.4",
     "mocha": "^2.4.5",
     "passport": "^0.3.2",
-    "should": "^8.2.2"
+    "should": "^8.2.2",
+    "sinon": "^1.17.4"
   }
 }

--- a/test/fixtures/mock-ldap-client.js
+++ b/test/fixtures/mock-ldap-client.js
@@ -1,0 +1,48 @@
+import sinon from 'sinon';
+
+const eventErrorCallbacks = {};
+const eventSearchCallbacks = {};
+const mockLdapClient = {
+    'eventError': null,
+    'searchError': null,
+    'on': sinon.spy((event, callback) => {
+        eventErrorCallbacks[event] = callback;
+    }),
+    'bind': sinon.spy((user, pass, callback) => {
+        if (mockLdapClient.eventError) {
+            return eventErrorCallbacks.error(mockLdapClient.eventError);
+        }
+        return callback();
+    }),
+    'mockSearchRes': {
+        'on': sinon.spy((event, callback) => {
+            eventSearchCallbacks[event] = callback;
+            // trigger the events once we've received
+            // a listener for 'end'
+            if (event === 'end') {
+                return mockLdapClient.searchStart();
+            }
+        })
+    },
+    'searchStart': sinon.spy(() => {
+        if (mockLdapClient.searchError) {
+            return eventSearchCallbacks.error(mockLdapClient.searchError);
+        }
+        return eventSearchCallbacks.end({
+            'status': 0
+        });
+    }),
+    'search': sinon.spy((base, filter, callback) => {
+        callback(null, mockLdapClient.mockSearchRes);
+    })
+};
+const notFoundError = new Error();
+notFoundError.code = 'ENOTFOUND';
+
+const connRefusedError = new Error();
+connRefusedError.code = 'ECONNREFUSED';
+
+const ldapSearchError = new Error();
+ldapSearchError.code = 'LDAPSEARCHERR';
+
+export {connRefusedError, mockLdapClient, notFoundError, ldapSearchError};

--- a/test/functionality.test.js
+++ b/test/functionality.test.js
@@ -5,19 +5,15 @@ import sessionUtil from './fixtures/session-util';
 import should from 'should';
 
 describe('when constructed with', () => {
-
     let mockServer = null;
-    const verify = (data, done) => {
-        return done(null, data);
-    };
+    const verify = (data, done) => done(null, data);
 
     // setup mock ldap server to test against
     before((done) => {
         mockServer = new mockLdapServer();
-        mockServer.start(constants.MOCK_SERVER_PORT)
-            .then(() => {
-                return done();
-            });
+        mockServer
+            .start(constants.MOCK_SERVER_PORT)
+            .then(() => done());
     });
 
     after(() => {
@@ -64,9 +60,7 @@ describe('when constructed with', () => {
             should(res[0]).have.property('name', 'testuser');
             return done();
         })
-        .catch((err) => {
-            return done(err);
-        });
+        .catch(err => done(err));
     });
 
     it('search, authenticate should sucessfully auth and return the user groups', (done) => {
@@ -94,9 +88,6 @@ describe('when constructed with', () => {
             should(res[1]).have.property('cn', 'developers');
             return done();
         })
-        .catch((err) => {
-            return done(err);
-        });
+        .catch(err => done(err));
     });
-
 });

--- a/test/functionality.test.js
+++ b/test/functionality.test.js
@@ -7,7 +7,7 @@ import should from 'should';
 describe('when constructed with', () => {
 
     let mockServer = null;
-    let verify = (data, done) => {
+    const verify = (data, done) => {
         return done(null, data);
     };
 
@@ -30,7 +30,7 @@ describe('when constructed with', () => {
 
 
     it('no search, authenticate should sucessfully auth and return the dn', () => {
-        let strat = new ldapStrat(
+        const strat = new ldapStrat(
             sessionUtil.getOptions({
                 'uidTag': 'uid',
                 'base': 'ou=people,dc=dev,ou=passport-ldap-strat',
@@ -38,12 +38,12 @@ describe('when constructed with', () => {
             }),
             verify
         );
-        let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+        const res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
         return should(res).be.fulfilledWith('uid=testuser,ou=people,dc=dev,ou=passport-ldap-strat');
     });
 
     it('search, authenticate should sucessfully auth and return the user info', (done) => {
-        let strat = new ldapStrat(
+        const strat = new ldapStrat(
             sessionUtil.getOptions({
                 'uidTag': 'uid',
                 'base': 'ou=people,dc=dev,ou=passport-ldap-strat',
@@ -70,7 +70,7 @@ describe('when constructed with', () => {
     });
 
     it('search, authenticate should sucessfully auth and return the user groups', (done) => {
-        let strat = new ldapStrat(
+        const strat = new ldapStrat(
             sessionUtil.getOptions({
                 'uidTag': 'uid',
                 'base': 'ou=people,dc=dev,ou=passport-ldap-strat',

--- a/test/functionality.test.js
+++ b/test/functionality.test.js
@@ -29,7 +29,7 @@ describe('when constructed with', () => {
     });
 
 
-    it('no search, authenticate should sucessfully auth and return the dn', (done) => {
+    it('no search, authenticate should sucessfully auth and return the dn', () => {
         let strat = new ldapStrat(
             sessionUtil.getOptions({
                 'uidTag': 'uid',
@@ -38,15 +38,8 @@ describe('when constructed with', () => {
             }),
             verify
         );
-        strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}})
-        .then((res) => {
-            should.exist(res);
-            should(res).equal('uid=testuser,ou=people,dc=dev,ou=passport-ldap-strat');
-            return done();
-        })
-        .catch((err) => {
-            return done(err);
-        });
+        let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+        return should(res).be.fulfilledWith('uid=testuser,ou=people,dc=dev,ou=passport-ldap-strat');
     });
 
     it('search, authenticate should sucessfully auth and return the user info', (done) => {

--- a/test/passport.test.js
+++ b/test/passport.test.js
@@ -8,12 +8,12 @@ import passport from 'passport';
 
 describe('when using passport', () => {
 
-    let verify = (data, done) => {
+    const verify = (data, done) => {
         return done(null, data);
     };
     let mockServer = null;
-    let app = express();
-    let options = sessionUtil.getOptions({
+    const app = express();
+    const options = sessionUtil.getOptions({
         'uidTag': 'uid',
         'base': 'ou=people,dc=dev,ou=passport-ldap-strat',
         'url': `${constants.MOCK_SERVER_URL}:${constants.MOCK_SERVER_PORT}`
@@ -129,7 +129,7 @@ describe('when using passport', () => {
 
     describe('with valid credentials and search options', () => {
 
-        let options = sessionUtil.getOptions({
+        const options = sessionUtil.getOptions({
             'uidTag': 'uid',
             'base': 'ou=people,dc=dev,ou=passport-ldap-strat',
             'url': `${constants.MOCK_SERVER_URL}:${constants.MOCK_SERVER_PORT}`,

--- a/test/passport.test.js
+++ b/test/passport.test.js
@@ -7,10 +7,7 @@ import sessionUtil from './fixtures/session-util';
 import passport from 'passport';
 
 describe('when using passport', () => {
-
-    const verify = (data, done) => {
-        return done(null, data);
-    };
+    const verify = (data, done) => done(null, data);
     let mockServer = null;
     const app = express();
     const options = sessionUtil.getOptions({
@@ -22,10 +19,9 @@ describe('when using passport', () => {
     // setup mock ldap server to test against
     before((done) => {
         mockServer = new mockLdapServer();
-        mockServer.start(constants.MOCK_SERVER_PORT)
-            .then(() => {
-                return done();
-            });
+        mockServer
+            .start(constants.MOCK_SERVER_PORT)
+            .then(() => done());
     });
 
     after(() => {
@@ -37,7 +33,6 @@ describe('when using passport', () => {
     });
 
     describe('with invalid credentials', () => {
-
         it('`badpass` password, should return InvalidCredentialsError', (done) => {
             passport.use(new ldapStrat(options, verify));
             app.use(passport.initialize());
@@ -88,11 +83,9 @@ describe('when using passport', () => {
                 return done();
             })({'body': {'username': 'notauser', 'password': 'test123'}}, {});
         });
-
     });
 
     describe('with valid credentials for', () => {
-
         it('`testuser`, should return user bind dn', (done) => {
             passport.use(new ldapStrat(options, verify));
             app.use(passport.initialize());
@@ -124,11 +117,9 @@ describe('when using passport', () => {
                 return done();
             })({'body': {'username': 'randomuser', 'password': 'test123'}}, {});
         });
-
     });
 
     describe('with valid credentials and search options', () => {
-
         const options = sessionUtil.getOptions({
             'uidTag': 'uid',
             'base': 'ou=people,dc=dev,ou=passport-ldap-strat',
@@ -160,7 +151,5 @@ describe('when using passport', () => {
                 return done();
             })({'body': {'username': 'testuser', 'password': 'test123'}}, {});
         });
-
     });
-
 });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,15 +1,16 @@
+import should from 'should';
+import sinon from 'sinon';
+
 import ldapStrat from '../';
 import * as constants from './fixtures/constants';
-import mockLdapServer from './fixtures/ldap-server';
+import * as client from './fixtures/mock-ldap-client';
 import sessionUtil from './fixtures/session-util';
-import should from 'should';
 
 let verify = (data, done) => {
     return done(null, data);
 };
 
 describe('when imported', () => {
-
     it('should be a class', (done) => {
         should(ldapStrat).be.type('function');
         return done();
@@ -23,11 +24,9 @@ describe('when imported', () => {
         }).not.throw();
         return done();
     });
-
 });
 
 describe('when constructed', () => {
-
     it('with no parameters, should throw an error', (done) => {
         should(() => {
             let strat = new ldapStrat();
@@ -74,126 +73,100 @@ describe('when constructed', () => {
         }).not.throw();
         return done();
     });
-
 });
 
-describe('when authenticate is called', () => {
-    it('with bad server name, throw an error', (done) => {
-        let strat = new ldapStrat(
-            sessionUtil.getOptions({
-                'uidTag': 'uid',
-                'server': {
-                    'url': 'ldap://nosuchserver:389'
-                }
-            }),
-            verify
-        );
-        strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}})
-        .then(() => {
-            return done(new Error('expected an error'));
-        })
-        .catch((err) => {
-            should(err).have.property('code', 'ENOTFOUND');
-            return done();
-        });
-    });
-    it('with unresponsive host, throw an error', (done) => {
-        let strat = new ldapStrat(
-            sessionUtil.getOptions({
-                'uidTag': 'uid',
-                // This automatically tries to connect to localhost
-                'url': 'ldap://'
-            }),
-            verify
-        );
-        strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}})
-        .then(() => {
-            return done(new Error('expected an error'));
-        })
-        .catch((err) => {
-            should(err).have.property('code', 'ECONNREFUSED');
-            return done();
-        });
-    });
-});
+describe('for client methods', () => {
+    const strat = new ldapStrat(
+        sessionUtil.getOptions({
+            'uidTag': 'uid',
+            'url': `${constants.MOCK_SERVER_URL}:${constants.MOCK_SERVER_PORT}`
+        }),
+        verify
+    );
 
-describe('when authenticate is called', () => {
-
-    let mockServer = null;
-
-    // setup mock ldap server to test against
-    before((done) => {
-        mockServer = new mockLdapServer();
-        mockServer.start(constants.MOCK_SERVER_PORT)
-            .then(() => {
-                return done();
-            });
+    before(() => {
+        sinon.stub(ldapStrat, '_createLdapClient').returns(client.mockLdapClient);
     });
 
     after(() => {
-        if (!mockServer) {
-            return;
-        }
-        mockServer.close();
-        mockServer = null;
+        ldapStrat._createLdapClient.restore();
     });
 
-    let strat = null;
-
-    // setup a new strat to test with
     beforeEach(() => {
-        strat = new ldapStrat(
-            sessionUtil.getOptions({
-                'uidTag': 'uid',
-                'url': `${constants.MOCK_SERVER_URL}:${constants.MOCK_SERVER_PORT}`
-            }),
-            verify
-        );
+        client.mockLdapClient.bind.reset();
+        client.mockLdapClient.search.reset();
+        client.mockLdapClient.mockSearchRes.on.reset();
     });
 
-    afterEach(() => {
-        strat = null;
-    });
+    describe('when authenticate is called', () => {
+        it('should reject for bad server name error event', () => {
+            client.mockLdapClient.eventError = client.notFoundError;
+            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            client.mockLdapClient.eventError = null;
+            should(res).be.a.Promise();
+            should(client.mockLdapClient.bind.calledOnce).be.ok();
+            return should(res).be.rejectedWith({ 'code': 'ENOTFOUND' })
+        });
 
-    it('with no params, should throw an error', (done) => {
-        strat.authenticate()
-        .then(() => {
-            return done(new Error('expected an error'));
-        })
-        .catch(() => {
-            return done();
+        it('should reject for unresponsive host error event', () => {
+            client.mockLdapClient.eventError = client.connRefusedError;
+            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            client.mockLdapClient.eventError = null;
+            should(res).be.a.Promise();
+            should(client.mockLdapClient.bind.calledOnce).be.ok();
+            return should(res).be.rejectedWith({ 'code': 'ECONNREFUSED' });
+        });
+
+        it('with no params, should throw an error', () => {
+            let res = strat.authenticate();
+            should(res).be.a.Promise();
+            return should(res).be.rejectedWith({ 'message': 'Missing req parameter.' });
+        });
+
+        it('with null req, should throw an error', () => {
+            let res = strat.authenticate(null);
+            should(res).be.a.Promise();
+            return should(res).be.rejectedWith({ 'message': 'Missing req parameter.' });
+        });
+
+        it('with req, but no body, should throw an error', () => {
+            let res = strat.authenticate({});
+            should(res).be.a.Promise();
+            return should(res).be.rejectedWith({ 'message': 'Missing username or password parameters.' });
+        });
+
+        it('should not throw an error', () => {
+            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            should(res).be.a.Promise();
+            return should(res).be.fulfilled();
+        });
+
+        describe('when _bind is called', () => {
+            it('should bind and resolve a promise', () => {
+                let res = strat._bind(client.mockLdapClient, {'username': 'testuser', 'password': 'test123'});
+                should(res).be.a.Promise();
+                should(client.mockLdapClient.bind.calledOnce).be.ok();
+                return should(res).be.fulfilled();
+            });
+        });
+
+        describe('when _search is called', () => {
+            it('should search and resolve a promise', () => {
+                let res = strat._search(client.mockLdapClient, {});
+                should(res).be.a.Promise();
+                should(client.mockLdapClient.mockSearchRes.on.callCount).be.eql(4);
+                return should(res).be.fulfilled();
+            });
+
+            it('should reject a promise on search error', () => {
+                client.mockLdapClient.searchError = client.ldapSearchError;
+                let res = strat._search(client.mockLdapClient, {});
+                should(client.mockLdapClient.search.calledOnce).be.ok();
+                should(res).be.a.Promise();
+                should(client.mockLdapClient.mockSearchRes.on.callCount).be.eql(4);
+                client.mockLdapClient.searchError = null;
+                return should(res).be.rejectedWith({ code: 'LDAPSEARCHERR' });
+            });
         });
     });
-
-    it('with null req, should throw an error', (done) => {
-        strat.authenticate(null)
-        .then(() => {
-            return done(new Error('expected an error'));
-        })
-        .catch(() => {
-            return done();
-        });
-    });
-
-    it('with req, but no body, should throw an error', (done) => {
-        strat.authenticate({})
-        .then(() => {
-            return done(new Error('expected an error'));
-        })
-        .catch(() => {
-            return done();
-        });
-    });
-
-    it('should not throw an error', (done) => {
-        strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}})
-        .then(() => {
-            return done();
-        })
-        .catch((err) => {
-            return done(err);
-        });
-    });
-
-
 });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6,9 +6,7 @@ import * as constants from './fixtures/constants';
 import * as client from './fixtures/mock-ldap-client';
 import sessionUtil from './fixtures/session-util';
 
-const verify = (data, done) => {
-    return done(null, data);
-};
+const verify = (data, done) => done(null, data);
 
 describe('when imported', () => {
     it('should be a class', (done) => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6,7 +6,7 @@ import * as constants from './fixtures/constants';
 import * as client from './fixtures/mock-ldap-client';
 import sessionUtil from './fixtures/session-util';
 
-let verify = (data, done) => {
+const verify = (data, done) => {
     return done(null, data);
 };
 
@@ -18,7 +18,7 @@ describe('when imported', () => {
 
     it('should be constructable', (done) => {
         should(() => {
-            let strat = new ldapStrat(sessionUtil.getOptions(), verify);
+            const strat = new ldapStrat(sessionUtil.getOptions(), verify);
             should(strat).be.type('object');
             should(strat).ok();
         }).not.throw();
@@ -29,7 +29,7 @@ describe('when imported', () => {
 describe('when constructed', () => {
     it('with no parameters, should throw an error', (done) => {
         should(() => {
-            let strat = new ldapStrat();
+            const strat = new ldapStrat();
             should.not.exist(strat);
         }).throw(Error);
         return done();
@@ -37,7 +37,7 @@ describe('when constructed', () => {
 
     it('with null options, should throw an error', (done) => {
         should(() => {
-            let strat = new ldapStrat(null);
+            const strat = new ldapStrat(null);
             should.not.exist(strat);
         }).throw(Error);
         return done();
@@ -45,7 +45,7 @@ describe('when constructed', () => {
 
     it('with no verify, should not throw an error', (done) => {
         should(() => {
-            let strat = new ldapStrat(sessionUtil.getOptions());
+            const strat = new ldapStrat(sessionUtil.getOptions());
             should(strat).be.type('object');
             should(strat).ok();
         }).not.throw();
@@ -54,7 +54,7 @@ describe('when constructed', () => {
 
     it('should not throw an error', (done) => {
         should(() => {
-            let strat = new ldapStrat(sessionUtil.getOptions(), verify);
+            const strat = new ldapStrat(sessionUtil.getOptions(), verify);
             should(strat).be.type('object');
             should(strat).ok();
         }).not.throw();
@@ -62,9 +62,9 @@ describe('when constructed', () => {
     });
 
     it('should set some properties', (done) => {
-        let options = sessionUtil.getOptions();
+        const options = sessionUtil.getOptions();
         should(() => {
-            let strat = new ldapStrat(options, verify);
+            const strat = new ldapStrat(options, verify);
             should(strat).be.type('object');
             should(strat).ok();
             should(strat).have.property('name', 'ldap');
@@ -101,7 +101,7 @@ describe('for client methods', () => {
     describe('when authenticate is called', () => {
         it('should reject for bad server name error event', () => {
             client.mockLdapClient.eventError = client.notFoundError;
-            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            const res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
             client.mockLdapClient.eventError = null;
             should(res).be.a.Promise();
             should(client.mockLdapClient.bind.calledOnce).be.ok();
@@ -110,7 +110,7 @@ describe('for client methods', () => {
 
         it('should reject for unresponsive host error event', () => {
             client.mockLdapClient.eventError = client.connRefusedError;
-            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            const res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
             client.mockLdapClient.eventError = null;
             should(res).be.a.Promise();
             should(client.mockLdapClient.bind.calledOnce).be.ok();
@@ -118,32 +118,32 @@ describe('for client methods', () => {
         });
 
         it('with no params, should throw an error', () => {
-            let res = strat.authenticate();
+            const res = strat.authenticate();
             should(res).be.a.Promise();
             return should(res).be.rejectedWith({ 'message': 'Missing req parameter.' });
         });
 
         it('with null req, should throw an error', () => {
-            let res = strat.authenticate(null);
+            const res = strat.authenticate(null);
             should(res).be.a.Promise();
             return should(res).be.rejectedWith({ 'message': 'Missing req parameter.' });
         });
 
         it('with req, but no body, should throw an error', () => {
-            let res = strat.authenticate({});
+            const res = strat.authenticate({});
             should(res).be.a.Promise();
             return should(res).be.rejectedWith({ 'message': 'Missing username or password parameters.' });
         });
 
         it('should not throw an error', () => {
-            let res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
+            const res = strat.authenticate({'body': {'username': 'testuser', 'password': 'test123'}});
             should(res).be.a.Promise();
             return should(res).be.fulfilled();
         });
 
         describe('when _bind is called', () => {
             it('should bind and resolve a promise', () => {
-                let res = strat._bind(client.mockLdapClient, {'username': 'testuser', 'password': 'test123'});
+                const res = strat._bind(client.mockLdapClient, {'username': 'testuser', 'password': 'test123'});
                 should(res).be.a.Promise();
                 should(client.mockLdapClient.bind.calledOnce).be.ok();
                 return should(res).be.fulfilled();
@@ -152,7 +152,7 @@ describe('for client methods', () => {
 
         describe('when _search is called', () => {
             it('should search and resolve a promise', () => {
-                let res = strat._search(client.mockLdapClient, {});
+                const res = strat._search(client.mockLdapClient, {});
                 should(res).be.a.Promise();
                 should(client.mockLdapClient.mockSearchRes.on.callCount).be.eql(4);
                 return should(res).be.fulfilled();
@@ -160,7 +160,7 @@ describe('for client methods', () => {
 
             it('should reject a promise on search error', () => {
                 client.mockLdapClient.searchError = client.ldapSearchError;
-                let res = strat._search(client.mockLdapClient, {});
+                const res = strat._search(client.mockLdapClient, {});
                 should(client.mockLdapClient.search.calledOnce).be.ok();
                 should(res).be.a.Promise();
                 should(client.mockLdapClient.mockSearchRes.on.callCount).be.eql(4);


### PR DESCRIPTION
General cleanup in unit tests, and we need to include the dist folder so we don't keep babel as a dependency.
